### PR TITLE
Entries Subset Craft3 availability plugin mapping

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -37,6 +37,9 @@ return [
     'DeleteAllEntryVersions' => [
         'handle' => 'delete-entry-versions'
     ],
+    'EntriesSubset' => [
+        'handle' => 'entriessubset'
+    ],
     'Hacksaw' => [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Typogrify](https://github.com/nystudio107/craft3-typogrify) could be used instead'


### PR DESCRIPTION
Added custom mapping for Entries Subset plugin as I noticed it wasn't showing as available on the "Craft 3 Plugin Availability" section in Craft 2