### PR TITLE
Add Scout & Colour Swatches

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -48,7 +48,6 @@ return [
         'status' => 'Discontinued (use [Simple Text](https://github.com/craftcms/simple-text) instead)'
     ],
     'ColorSwatches' => [
-        'handle' => 'colorswatches',
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Colour Swatches](https://github.com/rias500/craft-colour-swatches) could be used instead'
     ],

--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -30,7 +30,6 @@ return [
         'status' => 'Currently in development'
     ],
     'Algolia' => [
-        'handle' => 'algolia',
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Scout](https://github.com/rias500/craft-scout) could be used instead'
     ],
@@ -48,7 +47,7 @@ return [
         'statusColor' => 'red',
         'status' => 'Discontinued (use [Simple Text](https://github.com/craftcms/simple-text) instead)'
     ],
-    'Color Swatches' => [
+    'ColorSwatches' => [
         'handle' => 'colorswatches',
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Colour Swatches](https://github.com/rias500/craft-colour-swatches) could be used instead'

--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -29,6 +29,11 @@ return [
         'statusColor' => 'orange',
         'status' => 'Currently in development'
     ],
+    'Algolia' => [
+        'handle' => 'algolia',
+        'statusColor' => 'orange',
+        'status' => 'Not available yet, but [Scout](https://github.com/rias500/craft-scout) could be used instead'
+    ],
     'AmCommand' => [
         'handle' => 'command-palette',
     ],
@@ -42,6 +47,11 @@ return [
     'CodeBlock' => [
         'statusColor' => 'red',
         'status' => 'Discontinued (use [Simple Text](https://github.com/craftcms/simple-text) instead)'
+    ],
+    'Color Swatches' => [
+        'handle' => 'colorswatches',
+        'statusColor' => 'orange',
+        'status' => 'Not available yet, but [Colour Swatches](https://github.com/rias500/craft-colour-swatches) could be used instead'
     ],
     'CpFieldLinks' => [
         'handle' => 'cp-field-inspect'


### PR DESCRIPTION
- Scout can be used to replace algolia
- Colour Swatches is a port of the Craft 2 Color Swatches plugin