### PR TITLE
Adds Cache Flag and Retcon plugins to craft2-plugins.php

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -49,6 +49,10 @@ return [
         'statusColor' => 'red',
         'status' => 'Must be updated manually. Use [pluginfactory.io](https://pluginfactory.io/) to generate a Craft 3 plugin scaffolding.'
     ],
+    'CacheFlag' => [
+        'statusColor' => 'orange',
+        'status' => 'Coming soon'
+    ],
     'CodeBlock' => [
         'statusColor' => 'red',
         'status' => 'Discontinued (use [Simple Text](https://github.com/craftcms/simple-text) instead)'
@@ -126,6 +130,11 @@ return [
     'RedactorI' => [
         'statusColor' => 'red',
         'status' => 'Discontinued (use [Redactor](https://github.com/craftcms/redactor) instead)'
+    ],
+    'RetconHtml' => [
+        'handle' => 'retcon',
+        'statusColor' => 'orange',
+        'status' => 'Coming soon'
     ],
     'Retour' => [
         'statusColor' => 'orange',


### PR DESCRIPTION
Adds availability status for Cache Flag and Retcon plugins (the latter's handle has also changed for Craft 3)